### PR TITLE
Include txt test files in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include INSTALL
 include CONTRIBUTORS
 include Makefile
 include *.py
+include *.txt


### PR DESCRIPTION
Otherwise the doctests examples aren't included in the source distribution and run_all_examples.py fails
